### PR TITLE
w & s initialized as new int arrays and deleted accordingly

### DIFF
--- a/src/SHA256.cpp
+++ b/src/SHA256.cpp
@@ -93,8 +93,8 @@ uint32** SHA256::preprocess(const unsigned char* input, size_t &nBuffer){
  * @param h array of output message digest
  */
 void SHA256::process(uint32** buffer, size_t nBuffer, uint32* h){
-	uint32 s[WORKING_VAR_LEN];
-	uint32 w[MESSAGE_SCHEDULE_LEN]; 
+	uint32 *s = new uint32[WORKING_VAR_LEN];
+	uint32 *w = new uint32[MESSAGE_SCHEDULE_LEN]; 
 
 	memcpy(h, hPrime, WORKING_VAR_LEN*sizeof(uint32));
 
@@ -129,7 +129,8 @@ void SHA256::process(uint32** buffer, size_t nBuffer, uint32* h){
 			h[j] += s[j];
 		}
 	}
-
+	delete[] s;
+	delete[] w;
 }
 
 /**

--- a/src/SHA384.cpp
+++ b/src/SHA384.cpp
@@ -92,8 +92,8 @@ uint64** SHA384::preprocess(const unsigned char* input, size_t &nBuffer){
  * @param h array of output message digest
  */
 void SHA384::process(uint64** buffer, size_t nBuffer, uint64* h){
-	uint64 s[WORKING_VAR_LEN];
-	uint64 w[MESSAGE_SCHEDULE_LEN]; 
+	uint64 *s = new uint64[WORKING_VAR_LEN];
+	uint64 *w = new uint64[MESSAGE_SCHEDULE_LEN]; 
 
 	memcpy(h, hPrime, WORKING_VAR_LEN*sizeof(uint64));
 
@@ -128,7 +128,8 @@ void SHA384::process(uint64** buffer, size_t nBuffer, uint64* h){
 			h[j] += s[j];
 		}
 	}
-
+	delete[] s;
+	delete[] w;
 }
 
 /**

--- a/src/SHA512.cpp
+++ b/src/SHA512.cpp
@@ -92,8 +92,8 @@ uint64** SHA512::preprocess(const unsigned char* input, size_t &nBuffer){
  * @param h array of output message digest
  */
 void SHA512::process(uint64** buffer, size_t nBuffer, uint64* h){
-	uint64 s[WORKING_VAR_LEN];
-	uint64 w[MESSAGE_SCHEDULE_LEN]; 
+	uint64 *s = new uint64[WORKING_VAR_LEN];
+	uint64 *w = new uint64[MESSAGE_SCHEDULE_LEN]; 
 
 	memcpy(h, hPrime, WORKING_VAR_LEN*sizeof(uint64));
 
@@ -128,7 +128,8 @@ void SHA512::process(uint64** buffer, size_t nBuffer, uint64* h){
 			h[j] += s[j];
 		}
 	}
-
+	delete[] s;
+	delete[] w;
 }
 
 /**


### PR DESCRIPTION
Fixes build issue on Windows where the array is not assignable, nor can it be instantiated